### PR TITLE
Get subscription should return a Subscription object instead of "void…

### DIFF
--- a/src/AzureStack/SubscriptionsAdmin/Subscriptions.Admin.Tests/SessionRecords/SubscriptionsAdminClient/CreateUpdateDeleteSubscription.json
+++ b/src/AzureStack/SubscriptionsAdmin/Subscriptions.Admin.Tests/SessionRecords/SubscriptionsAdminClient/CreateUpdateDeleteSubscription.json
@@ -1,0 +1,301 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "/subscriptions/d16dfcf0-44cc-4498-9937-08b94159d27b/providers/Microsoft.Subscriptions.Admin/offers?api-version=2015-11-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZDE2ZGZjZjAtNDRjYy00NDk4LTk5MzctMDhiOTQxNTlkMjdiL3Byb3ZpZGVycy9NaWNyb3NvZnQuU3Vic2NyaXB0aW9ucy5BZG1pbi9vZmZlcnM/YXBpLXZlcnNpb249MjAxNS0xMS0wMQ==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "9cf9daf6-aa2c-490b-af4c-51029de159a0"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.AzureStack.Management.Subscriptions.Admin.SubscriptionsAdminClient/0.1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"id\": \"/subscriptions/d16dfcf0-44cc-4498-9937-08b94159d27b/resourceGroups/planrg/providers/Microsoft.Subscriptions.Admin/offers/testoffer\",\r\n      \"name\": \"testoffer\",\r\n      \"type\": \"Microsoft.Subscriptions.Admin/offers\",\r\n      \"location\": \"local\",\r\n      \"properties\": {\r\n        \"name\": \"testoffer\",\r\n        \"displayName\": \"testoffer\",\r\n        \"state\": \"Private\",\r\n        \"subscriptionCount\": 0,\r\n        \"maxSubscriptionsPerAccount\": 0,\r\n        \"basePlanIds\": [\r\n          \"/subscriptions/d16dfcf0-44cc-4498-9937-08b94159d27b/resourceGroups/planrg/providers/Microsoft.Subscriptions.Admin/plans/testplan\"\r\n        ],\r\n        \"addonPlans\": []\r\n      }\r\n    }\r\n  ]\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "529"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 16 Mar 2018 04:41:59 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14837"
+        ],
+        "x-ms-request-id": [
+          "f60f7ced-0d8e-490f-9c05-8cb328cad1e2"
+        ],
+        "x-ms-correlation-request-id": [
+          "f60f7ced-0d8e-490f-9c05-8cb328cad1e2"
+        ],
+        "x-ms-routing-request-id": [
+          "LOCAL:20180316T044159Z:f60f7ced-0d8e-490f-9c05-8cb328cad1e2"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/d16dfcf0-44cc-4498-9937-08b94159d27b/providers/Microsoft.Subscriptions.Admin/subscriptions/c79389af-4480-48cc-8fa2-ee8ced8e843d?api-version=2015-11-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZDE2ZGZjZjAtNDRjYy00NDk4LTk5MzctMDhiOTQxNTlkMjdiL3Byb3ZpZGVycy9NaWNyb3NvZnQuU3Vic2NyaXB0aW9ucy5BZG1pbi9zdWJzY3JpcHRpb25zL2M3OTM4OWFmLTQ0ODAtNDhjYy04ZmEyLWVlOGNlZDhlODQzZD9hcGktdmVyc2lvbj0yMDE1LTExLTAx",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"delegatedProviderSubscriptionId\": \"d16dfcf0-44cc-4498-9937-08b94159d27b\",\r\n  \"displayName\": \"Test Subscription\",\r\n  \"offerId\": \"/subscriptions/d16dfcf0-44cc-4498-9937-08b94159d27b/resourceGroups/planrg/providers/Microsoft.Subscriptions.Admin/offers/testoffer\",\r\n  \"owner\": \"tenantadmin1@msazurestack.onmicrosoft.com\",\r\n  \"state\": \"Enabled\",\r\n  \"subscriptionId\": \"c79389af-4480-48cc-8fa2-ee8ced8e843d\",\r\n  \"tenantId\": \"104edf09-7fc1-459f-8c4e-b062db480b90\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "464"
+        ],
+        "x-ms-client-request-id": [
+          "6fce29fb-72bc-4d10-9424-de84efe1634a"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.AzureStack.Management.Subscriptions.Admin.SubscriptionsAdminClient/0.1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/d16dfcf0-44cc-4498-9937-08b94159d27b/providers/Microsoft.Subscriptions.Admin/subscriptions/c79389af-4480-48cc-8fa2-ee8ced8e843d\",\r\n  \"subscriptionId\": \"c79389af-4480-48cc-8fa2-ee8ced8e843d\",\r\n  \"delegatedProviderSubscriptionId\": \"d16dfcf0-44cc-4498-9937-08b94159d27b\",\r\n  \"displayName\": \"Test Subscription\",\r\n  \"owner\": \"tenantadmin1@msazurestack.onmicrosoft.com\",\r\n  \"tenantId\": \"104edf09-7fc1-459f-8c4e-b062db480b90\",\r\n  \"routingResourceManagerType\": \"Default\",\r\n  \"offerId\": \"/subscriptions/d16dfcf0-44cc-4498-9937-08b94159d27b/resourceGroups/planrg/providers/Microsoft.Subscriptions.Admin/offers/testoffer\",\r\n  \"state\": \"Enabled\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "616"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 16 Mar 2018 04:42:02 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1193"
+        ],
+        "x-ms-request-id": [
+          "eabe914f-91ee-4a0a-9d23-f3c1cdcd1fb0"
+        ],
+        "x-ms-correlation-request-id": [
+          "eabe914f-91ee-4a0a-9d23-f3c1cdcd1fb0"
+        ],
+        "x-ms-routing-request-id": [
+          "LOCAL:20180316T044202Z:eabe914f-91ee-4a0a-9d23-f3c1cdcd1fb0"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/d16dfcf0-44cc-4498-9937-08b94159d27b/providers/Microsoft.Subscriptions.Admin/subscriptions/c79389af-4480-48cc-8fa2-ee8ced8e843d?api-version=2015-11-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZDE2ZGZjZjAtNDRjYy00NDk4LTk5MzctMDhiOTQxNTlkMjdiL3Byb3ZpZGVycy9NaWNyb3NvZnQuU3Vic2NyaXB0aW9ucy5BZG1pbi9zdWJzY3JpcHRpb25zL2M3OTM4OWFmLTQ0ODAtNDhjYy04ZmEyLWVlOGNlZDhlODQzZD9hcGktdmVyc2lvbj0yMDE1LTExLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "dfd3788b-1dde-4bb9-b238-f22e5af7d4f7"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.AzureStack.Management.Subscriptions.Admin.SubscriptionsAdminClient/0.1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/d16dfcf0-44cc-4498-9937-08b94159d27b/providers/Microsoft.Subscriptions.Admin/subscriptions/c79389af-4480-48cc-8fa2-ee8ced8e843d\",\r\n  \"subscriptionId\": \"c79389af-4480-48cc-8fa2-ee8ced8e843d\",\r\n  \"delegatedProviderSubscriptionId\": \"d16dfcf0-44cc-4498-9937-08b94159d27b\",\r\n  \"displayName\": \"Test Subscription\",\r\n  \"owner\": \"tenantadmin1@msazurestack.onmicrosoft.com\",\r\n  \"tenantId\": \"104edf09-7fc1-459f-8c4e-b062db480b90\",\r\n  \"routingResourceManagerType\": \"Default\",\r\n  \"offerId\": \"/subscriptions/d16dfcf0-44cc-4498-9937-08b94159d27b/resourceGroups/planrg/providers/Microsoft.Subscriptions.Admin/offers/testoffer\",\r\n  \"state\": \"Enabled\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "616"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 16 Mar 2018 04:42:02 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14836"
+        ],
+        "x-ms-request-id": [
+          "229a922f-9b97-43a9-84de-ae3edd1004c2"
+        ],
+        "x-ms-correlation-request-id": [
+          "229a922f-9b97-43a9-84de-ae3edd1004c2"
+        ],
+        "x-ms-routing-request-id": [
+          "LOCAL:20180316T044202Z:229a922f-9b97-43a9-84de-ae3edd1004c2"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/d16dfcf0-44cc-4498-9937-08b94159d27b/providers/Microsoft.Subscriptions.Admin/subscriptions/c79389af-4480-48cc-8fa2-ee8ced8e843d?api-version=2015-11-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZDE2ZGZjZjAtNDRjYy00NDk4LTk5MzctMDhiOTQxNTlkMjdiL3Byb3ZpZGVycy9NaWNyb3NvZnQuU3Vic2NyaXB0aW9ucy5BZG1pbi9zdWJzY3JpcHRpb25zL2M3OTM4OWFmLTQ0ODAtNDhjYy04ZmEyLWVlOGNlZDhlODQzZD9hcGktdmVyc2lvbj0yMDE1LTExLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "7358480a-9bf9-4332-bf4d-84cfffde7735"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.AzureStack.Management.Subscriptions.Admin.SubscriptionsAdminClient/0.1.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"error\": {\r\n    \"code\": \"SubscriptionNotFound\",\r\n    \"message\": \"The subscription 'c79389af-4480-48cc-8fa2-ee8ced8e843d' could not be found.\"\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "129"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 16 Mar 2018 04:42:59 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14825"
+        ],
+        "x-ms-request-id": [
+          "27b335bc-c864-4eb5-913a-f140a61dbf80"
+        ],
+        "x-ms-correlation-request-id": [
+          "27b335bc-c864-4eb5-913a-f140a61dbf80"
+        ],
+        "x-ms-routing-request-id": [
+          "LOCAL:20180316T044259Z:27b335bc-c864-4eb5-913a-f140a61dbf80"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ]
+      },
+      "StatusCode": 404
+    },
+    {
+      "RequestUri": "/subscriptions/d16dfcf0-44cc-4498-9937-08b94159d27b/providers/Microsoft.Subscriptions.Admin/subscriptions/c79389af-4480-48cc-8fa2-ee8ced8e843d?api-version=2015-11-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZDE2ZGZjZjAtNDRjYy00NDk4LTk5MzctMDhiOTQxNTlkMjdiL3Byb3ZpZGVycy9NaWNyb3NvZnQuU3Vic2NyaXB0aW9ucy5BZG1pbi9zdWJzY3JpcHRpb25zL2M3OTM4OWFmLTQ0ODAtNDhjYy04ZmEyLWVlOGNlZDhlODQzZD9hcGktdmVyc2lvbj0yMDE1LTExLTAx",
+      "RequestMethod": "DELETE",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "a2efcf92-9030-40aa-9278-5eb182381e50"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.AzureStack.Management.Subscriptions.Admin.SubscriptionsAdminClient/0.1.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Fri, 16 Mar 2018 04:42:02 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1192"
+        ],
+        "x-ms-request-id": [
+          "b06a4d50-c9d3-4557-8513-b818d307944f"
+        ],
+        "x-ms-correlation-request-id": [
+          "b06a4d50-c9d3-4557-8513-b818d307944f"
+        ],
+        "x-ms-routing-request-id": [
+          "LOCAL:20180316T044202Z:b06a4d50-c9d3-4557-8513-b818d307944f"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ]
+      },
+      "StatusCode": 200
+    }
+  ],
+  "Names": {},
+  "Variables": {
+    "SubscriptionId": "d16dfcf0-44cc-4498-9937-08b94159d27b"
+  }
+}

--- a/src/AzureStack/SubscriptionsAdmin/Subscriptions.Admin.Tests/src/PlanTests.cs
+++ b/src/AzureStack/SubscriptionsAdmin/Subscriptions.Admin.Tests/src/PlanTests.cs
@@ -63,7 +63,7 @@ namespace Subscriptions.Tests
                 var location = "local";
                 var rg = "testrg";
                 var name = "testplans";
-                var descriptiopn = "description of the plan";
+                var description = "description of the plan";
 
                 var quota = client.Quotas.List(location).First();
 
@@ -74,7 +74,7 @@ namespace Subscriptions.Tests
                         planName: name,
                         displayName: name,
                         location: location,
-                        description: name,
+                        description: description,
                         quotaIds: new List<string> { quota.Id }
                     ));
 

--- a/src/AzureStack/SubscriptionsAdmin/Subscriptions.Admin/Subscriptions/Subscriptions.Admin/Generated/ISubscriptionsOperations.cs
+++ b/src/AzureStack/SubscriptionsAdmin/Subscriptions.Admin/Subscriptions/Subscriptions.Admin/Generated/ISubscriptionsOperations.cs
@@ -86,7 +86,7 @@ namespace Microsoft.AzureStack.Management.Subscriptions.Admin
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        Task<AzureOperationResponse> GetWithHttpMessagesAsync(string subscription, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<AzureOperationResponse<Subscription>> GetWithHttpMessagesAsync(string subscription, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Creates a new subscription.
         /// </summary>

--- a/src/AzureStack/SubscriptionsAdmin/Subscriptions.Admin/Subscriptions/Subscriptions.Admin/Generated/SubscriptionsOperationsExtensions.cs
+++ b/src/AzureStack/SubscriptionsAdmin/Subscriptions.Admin/Subscriptions/Subscriptions.Admin/Generated/SubscriptionsOperationsExtensions.cs
@@ -24,175 +24,178 @@ namespace Microsoft.AzureStack.Management.Subscriptions.Admin
     /// </summary>
     public static partial class SubscriptionsOperationsExtensions
     {
-            /// <summary>
-            /// Get the list of subscriptions.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='odataQuery'>
-            /// OData parameters to apply to the operation.
-            /// </param>
-            public static IEnumerable<Subscription> List(this ISubscriptionsOperations operations, ODataQuery<Subscription> odataQuery = default(ODataQuery<Subscription>))
-            {
-                return operations.ListAsync(odataQuery).GetAwaiter().GetResult();
-            }
+        /// <summary>
+        /// Get the list of subscriptions.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='odataQuery'>
+        /// OData parameters to apply to the operation.
+        /// </param>
+        public static IEnumerable<Subscription> List(this ISubscriptionsOperations operations, ODataQuery<Subscription> odataQuery = default(ODataQuery<Subscription>))
+        {
+            return operations.ListAsync(odataQuery).GetAwaiter().GetResult();
+        }
 
-            /// <summary>
-            /// Get the list of subscriptions.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='odataQuery'>
-            /// OData parameters to apply to the operation.
-            /// </param>
-            /// <param name='cancellationToken'>
-            /// The cancellation token.
-            /// </param>
-            public static async Task<IEnumerable<Subscription>> ListAsync(this ISubscriptionsOperations operations, ODataQuery<Subscription> odataQuery = default(ODataQuery<Subscription>), CancellationToken cancellationToken = default(CancellationToken))
+        /// <summary>
+        /// Get the list of subscriptions.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='odataQuery'>
+        /// OData parameters to apply to the operation.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        public static async Task<IEnumerable<Subscription>> ListAsync(this ISubscriptionsOperations operations, ODataQuery<Subscription> odataQuery = default(ODataQuery<Subscription>), CancellationToken cancellationToken = default(CancellationToken))
+        {
+            using (var _result = await operations.ListWithHttpMessagesAsync(odataQuery, null, cancellationToken).ConfigureAwait(false))
             {
-                using (var _result = await operations.ListWithHttpMessagesAsync(odataQuery, null, cancellationToken).ConfigureAwait(false))
-                {
-                    return _result.Body;
-                }
+                return _result.Body;
             }
+        }
 
-            /// <summary>
-            /// Get the list of subscriptions.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nameAvailabilityDefinition'>
-            /// Check name availability parameter
-            /// </param>
-            public static CheckNameAvailabilityResponse CheckNameAvailability(this ISubscriptionsOperations operations, CheckNameAvailabilityDefinition nameAvailabilityDefinition)
-            {
-                return operations.CheckNameAvailabilityAsync(nameAvailabilityDefinition).GetAwaiter().GetResult();
-            }
+        /// <summary>
+        /// Get the list of subscriptions.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='nameAvailabilityDefinition'>
+        /// Check name availability parameter
+        /// </param>
+        public static CheckNameAvailabilityResponse CheckNameAvailability(this ISubscriptionsOperations operations, CheckNameAvailabilityDefinition nameAvailabilityDefinition)
+        {
+            return operations.CheckNameAvailabilityAsync(nameAvailabilityDefinition).GetAwaiter().GetResult();
+        }
 
-            /// <summary>
-            /// Get the list of subscriptions.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='nameAvailabilityDefinition'>
-            /// Check name availability parameter
-            /// </param>
-            /// <param name='cancellationToken'>
-            /// The cancellation token.
-            /// </param>
-            public static async Task<CheckNameAvailabilityResponse> CheckNameAvailabilityAsync(this ISubscriptionsOperations operations, CheckNameAvailabilityDefinition nameAvailabilityDefinition, CancellationToken cancellationToken = default(CancellationToken))
+        /// <summary>
+        /// Get the list of subscriptions.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='nameAvailabilityDefinition'>
+        /// Check name availability parameter
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        public static async Task<CheckNameAvailabilityResponse> CheckNameAvailabilityAsync(this ISubscriptionsOperations operations, CheckNameAvailabilityDefinition nameAvailabilityDefinition, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            using (var _result = await operations.CheckNameAvailabilityWithHttpMessagesAsync(nameAvailabilityDefinition, null, cancellationToken).ConfigureAwait(false))
             {
-                using (var _result = await operations.CheckNameAvailabilityWithHttpMessagesAsync(nameAvailabilityDefinition, null, cancellationToken).ConfigureAwait(false))
-                {
-                    return _result.Body;
-                }
+                return _result.Body;
             }
+        }
 
-            /// <summary>
-            /// Get a specified subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='subscription'>
-            /// Subscription parameter.
-            /// </param>
-            public static void Get(this ISubscriptionsOperations operations, string subscription)
-            {
-                operations.GetAsync(subscription).GetAwaiter().GetResult();
-            }
+        /// <summary>
+        /// Get a specified subscription.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='subscription'>
+        /// Subscription parameter.
+        /// </param>
+        public static Subscription Get(this ISubscriptionsOperations operations, string subscription)
+        {
+            return operations.GetAsync(subscription).GetAwaiter().GetResult();
+        }
 
-            /// <summary>
-            /// Get a specified subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='subscription'>
-            /// Subscription parameter.
-            /// </param>
-            /// <param name='cancellationToken'>
-            /// The cancellation token.
-            /// </param>
-            public static async Task GetAsync(this ISubscriptionsOperations operations, string subscription, CancellationToken cancellationToken = default(CancellationToken))
+        /// <summary>
+        /// Get a specified subscription.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='subscription'>
+        /// Subscription parameter.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        public static async Task<Subscription> GetAsync(this ISubscriptionsOperations operations, string subscription, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            using (var _result = await operations.GetWithHttpMessagesAsync(subscription, null, cancellationToken).ConfigureAwait(false))
             {
-                (await operations.GetWithHttpMessagesAsync(subscription, null, cancellationToken).ConfigureAwait(false)).Dispose();
+                return _result.Body;
             }
+        }
 
-            /// <summary>
-            /// Creates a new subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='subscription'>
-            /// Subscription parameter.
-            /// </param>
-            /// <param name='newSubscription'>
-            /// Subscription parameter.
-            /// </param>
-            public static Subscription CreateOrUpdate(this ISubscriptionsOperations operations, string subscription, Subscription newSubscription)
-            {
-                return operations.CreateOrUpdateAsync(subscription, newSubscription).GetAwaiter().GetResult();
-            }
+        /// <summary>
+        /// Creates a new subscription.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='subscription'>
+        /// Subscription parameter.
+        /// </param>
+        /// <param name='newSubscription'>
+        /// Subscription parameter.
+        /// </param>
+        public static Subscription CreateOrUpdate(this ISubscriptionsOperations operations, string subscription, Subscription newSubscription)
+        {
+            return operations.CreateOrUpdateAsync(subscription, newSubscription).GetAwaiter().GetResult();
+        }
 
-            /// <summary>
-            /// Creates a new subscription.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='subscription'>
-            /// Subscription parameter.
-            /// </param>
-            /// <param name='newSubscription'>
-            /// Subscription parameter.
-            /// </param>
-            /// <param name='cancellationToken'>
-            /// The cancellation token.
-            /// </param>
-            public static async Task<Subscription> CreateOrUpdateAsync(this ISubscriptionsOperations operations, string subscription, Subscription newSubscription, CancellationToken cancellationToken = default(CancellationToken))
+        /// <summary>
+        /// Creates a new subscription.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='subscription'>
+        /// Subscription parameter.
+        /// </param>
+        /// <param name='newSubscription'>
+        /// Subscription parameter.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        public static async Task<Subscription> CreateOrUpdateAsync(this ISubscriptionsOperations operations, string subscription, Subscription newSubscription, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            using (var _result = await operations.CreateOrUpdateWithHttpMessagesAsync(subscription, newSubscription, null, cancellationToken).ConfigureAwait(false))
             {
-                using (var _result = await operations.CreateOrUpdateWithHttpMessagesAsync(subscription, newSubscription, null, cancellationToken).ConfigureAwait(false))
-                {
-                    return _result.Body;
-                }
+                return _result.Body;
             }
+        }
 
-            /// <summary>
-            /// Get the list of subscriptions.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='subscription'>
-            /// Subscription parameter.
-            /// </param>
-            public static void Delete(this ISubscriptionsOperations operations, string subscription)
-            {
-                operations.DeleteAsync(subscription).GetAwaiter().GetResult();
-            }
+        /// <summary>
+        /// Get the list of subscriptions.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='subscription'>
+        /// Subscription parameter.
+        /// </param>
+        public static void Delete(this ISubscriptionsOperations operations, string subscription)
+        {
+            operations.DeleteAsync(subscription).GetAwaiter().GetResult();
+        }
 
-            /// <summary>
-            /// Get the list of subscriptions.
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='subscription'>
-            /// Subscription parameter.
-            /// </param>
-            /// <param name='cancellationToken'>
-            /// The cancellation token.
-            /// </param>
-            public static async Task DeleteAsync(this ISubscriptionsOperations operations, string subscription, CancellationToken cancellationToken = default(CancellationToken))
-            {
-                (await operations.DeleteWithHttpMessagesAsync(subscription, null, cancellationToken).ConfigureAwait(false)).Dispose();
-            }
+        /// <summary>
+        /// Get the list of subscriptions.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='subscription'>
+        /// Subscription parameter.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        public static async Task DeleteAsync(this ISubscriptionsOperations operations, string subscription, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            (await operations.DeleteWithHttpMessagesAsync(subscription, null, cancellationToken).ConfigureAwait(false)).Dispose();
+        }
 
     }
 }


### PR DESCRIPTION
…" and subscription tests

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
